### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,31 +30,31 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>3.1.1.RELEASE</version>
+      <version>4.3.29.RELEASE</version>
     </dependency>
 
     <dependency>
         <groupId>org.apache.sling</groupId>
         <artifactId>org.apache.sling.engine</artifactId>
-        <version>2.0.4-incubator</version>
+        <version>2.4.6</version>
     </dependency>
 
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-saml-core</artifactId>
-      <version>1.8.1.Final</version>
+      <version>2.5.5.Final</version>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-jmx</artifactId>
-      <version>1.3</version>
+      <version>3.0.0-M05</version>
     </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.176</version>
+      <version>1.4.198</version>
     </dependency>
 
     <dependency>
@@ -66,13 +66,13 @@
     <dependency>
       <groupId>net.bull.javamelody</groupId>
       <artifactId>javamelody-core</artifactId>
-      <version>1.59.0</version>
+      <version>1.74.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.orientechnologies</groupId>
       <artifactId>orientdb-server</artifactId>
-      <version>2.1.9</version>
+      <version>2.1.11</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `org.springframework:spring-web` | 3.1.1.RELEASE | 4.3.29.RELEASE | Yes |
| MAVEN | `org.neo4j:neo4j-jmx` | 1.3 | 3.0.0-M05 | No |
| MAVEN | `com.h2database:h2` | 1.3.176 | 1.4.198 | No |
| MAVEN | `net.bull.javamelody:javamelody-core` | 1.59.0 | 1.74.0 | No |
| MAVEN | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.11 | No |
| MAVEN | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | No |
| MAVEN | `org.apache.sling:org.apache.sling.engine` | 2.0.4-incubator | 2.4.6 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/500t3Dn/scans/31828063).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-7335580b97e88bd57929baaf92904107b808b27280a10dbaf7d91427f8af34d7 -->
